### PR TITLE
2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: node_js
 before_install:
   - "npm install npm -g"
 node_js:
-  - "0.10"
   - "0.12"
-  - "iojs"
   - "4"
-  - "4.2"
   - "5"
   - "6"
+  - "7"
 after_success:
   - "npm run coveralls"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-bip38
-=====
+# bip38
 
 [![build status](https://secure.travis-ci.org/bitcoinjs/bip38.svg)](http://travis-ci.org/bitcoinjs/bip38)
 [![Coverage Status](https://img.shields.io/coveralls/cryptocoinjs/bip38.svg)](https://coveralls.io/r/cryptocoinjs/bip38)
@@ -10,14 +9,11 @@ bip38
 A JavaScript component that adheres to the [BIP38](https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki) standard to secure your crypto currency private keys. Fully compliant with Node.js and the browser (via Browserify).
 
 
-Why?
-----
-
+## Why?
 BIP38 is a standard process to encrypt Bitcoin and crypto currency private keys that is imprevious to brute force attacks thus protecting the user.
 
 
-Package Info
-------------
+## Package Info
 - homepage: [http://cryptocoinjs.com/modules/currency/bip38/](http://cryptocoinjs.com/modules/currency/bip38/)
 - github: [https://github.com/cryptocoinjs/bip38](https://github.com/cryptocoinjs/bip38)
 - tests: [https://github.com/cryptocoinjs/bip38/tree/master/test](https://github.com/cryptocoinjs/bip38/tree/master/test)
@@ -26,116 +22,49 @@ Package Info
 - versioning: [http://semver-ftw.org](http://semver-ftw.org)
 
 
-Usage
------
+## Usage
 
 ### Installation
 
     npm install --save bip38
 
 
-API
----
+### API
+### encrypt(buffer, compressed, passphrase, progressCallback)
 
-### Bip38([versions])
+``` javascript
+var bip38 = require('bip38')
+var wif = require('wif')
 
-Constructor that creates a new `Bip38` instance. 
+var myWifString = '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR'
+var decoded = wif.decode(myWifString)
 
-- **versions**: optional parameter to set the versions. Defaults to Bitcoin.
-
-
-### versions
-
-A field that accepts an object for the address version. This easily allows you to support altcoins. Defaults to Bitcoin values.
-
-
-**example:**
-
-```js
-var Bip38 = require('bip38')
-
-var privateKeyWif = '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR'
-
-var bip38 = new Bip38()
-
-// not necessary, as Bitcoin is supported by default
-bip38.versions = {
-	private: 0x80, 
-  public: 0x0
-}
-bip38.encrypt(privateKeyWif, "super-secret", "1Jq6MksXQVWzrznvZzxkV6oY57oWXD9TXB"})
-```
-
-### scryptParams
-
-A field that accepts an object with the follow properties: `N`, `r`, and `p` to control the [scrypt](https://github.com/cryptocoinjs/scryptsy). The
-BIP38 standard suggests `N = 16384`, `r = 8`, and `p = 8`. However, this may yield unacceptable performance on a mobile phone. If you alter these parameters, it wouldn't be wise to suggest to your users that your import/export encrypted keys are BIP38 compatible. If you do, you may want to alert them of your parameter changes.
-
-**example:**
-
-```js
-bip38.scryptParams = {
-  N: 8192, 
-  r: 8, 
-  p: 8
-}
-```
-
-
-### encrypt(wif, passphrase, address, progressCallback)
-
-A method that encrypts the private key. `wif` is the string value of the wallet import format key. `passphrase` the passphrase to encrypt the key with. `address` is the public address.
-`progressCallback` is a function that receives an object in the form of: 
-{current: 1000, total: 262144, percent: 0.3814697265625}
-
-
-Returns the encrypted string.
-
-**example**:
-
-```js
-var Bip38 = require('bip38')
-
-var privateKeyWif = '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR'
-
-var bip38 = new Bip38()
-var encrypted = bip38.encrypt(privateKeyWif, 'TestingOneTwoThree', "1Jq6MksXQVWzrznvZzxkV6oY57oWXD9TXB", function (status) {
-    console.log(status.percent) // Will print the precent every time current increases by 1000
-})
-console.log(encrypted) 
-// => 6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg
+var encryptedKey = bip38.encrypt(decoded.privateKey, decoded.compressed, 'TestingOneTwoThree')
+console.log(encryptedKey)
+// => '6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg'
 ```
 
 
 ### decrypt(encryptedKey, passhprase, progressCallback)
 
-A method that decrypts the encrypted string. `encryptedKey` is the string value of the encrypted key. `passphrase` is the passphrase to decrypt the key with.
-`progressCallback` is a function that receives an object in the form of: 
-{current: 1000, total: 262144, percent: 0.3814697265625}
-
-
-```js
-var Bip38 = require('bip38')
-
+``` javascript
+var bip38 = require('bip38')
 var encryptedKey = '6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg'
 
 var bip38 = new Bip38()
-var privateKeyWif = bip38.decrypt(encryptedKey, 'TestingOneTwoThree', function (status) {
-    console.log(status.percent) // Will print the precent every time current increases by 1000
+var decryptedKey = bip38.decrypt(encryptedKey, 'TestingOneTwoThree', function (status) {
+    console.log(status.percent) // will print the precent every time current increases by 1000
 })
-console.log(privateKeyWif) 
-// =>  '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR'
+
+console.log(wif.encode(decryptedKey.privateKey, decryptedKey.compressed))
+// => '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR'
 ```
 
-**note:** To check for an invalid password, you'll want to generate the public address from the output of the `decrypt()` function. If it doesn't equal the expected address or the address checksum, then chances are, it's an invalid password. The reason that this logic was not included is because it would have required a lot of dependencies: `ECKey` and `Address`. Currently, `ECKey` is pretty heavy on dependencies.
 
-
-
-References
-----------
+# References
 - https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki
 - https://github.com/pointbiz/bitaddress.org/issues/56 (Safari 6.05 issue)
 - https://github.com/casascius/Bitcoin-Address-Utility/tree/master/Model
 - https://github.com/nomorecoin/python-bip38-testing/blob/master/bip38.py
-- https://github.com/pointbiz/bitaddress.org/blob/master/src/ninja.key.js 
+- https://github.com/pointbiz/bitaddress.org/blob/master/src/ninja.key.js
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var aes = require('browserify-aes')
 var assert = require('assert')
+var bs58check = require('bs58check')
 var createHash = require('create-hash')
-var cs = require('coinstring')
 var scrypt = require('scryptsy')
 var xor = require('buffer-xor')
 
@@ -10,110 +10,114 @@ var curve = ecurve.getCurveByName('secp256k1')
 
 var BigInteger = require('bigi')
 
-// SHA256(SHA256(buffer))
-function sha256x2 (buffer) {
-  buffer = createHash('sha256').update(buffer).digest()
-  return createHash('sha256').update(buffer).digest()
+// constants
+var SCRYPT_PARAMS = {
+  N: 16384, // specified by BIP38
+  r: 8,
+  p: 8
+}
+var NULL = new Buffer(0)
+
+function hash160 (buffer) {
+  return createHash('rmd160').update(
+    createHash('sha256').update(buffer).digest()
+  ).digest()
 }
 
-function Bip38 (versions) {
-  if (!(this instanceof Bip38)) return new Bip38()
-
-  // default to Bitcoin WIF versions
-  this.versions = versions || { private: 0x80 }
-
-  // BIP38 recommended
-  this.scryptParams = {
-    N: 16384,
-    r: 8,
-    p: 8
-  }
+function hash256 (buffer) {
+  return createHash('sha256').update(
+    createHash('sha256').update(buffer).digest()
+  ).digest()
 }
 
-Bip38.prototype.encryptRaw = function (buffer, compressed, passphrase, saltAddress, progressCallback) {
-  assert.equal(buffer.length, 32, 'Invalid private key length')
+function getAddress (d, compressed) {
+  var Q = curve.G.multiply(d).getEncoded(compressed)
+  var hash = hash160(Q)
+  var payload = new Buffer(21)
+  payload.writeUInt8(0x00, 0) // XXX TODO FIXME bitcoin only??? damn you BIP38
+  hash.copy(payload, 1)
 
+  return bs58check.encode(payload)
+}
+
+function encryptRaw (buffer, compressed, passphrase, progressCallback) {
+  if (buffer.length !== 32) throw new Error('Invalid private key length')
+
+  var d = BigInteger.fromBuffer(buffer)
+  var address = getAddress(d)
   var secret = new Buffer(passphrase, 'utf8')
-  var salt = sha256x2(saltAddress).slice(0, 4)
+  var salt = hash256(address).slice(0, 4)
 
-  var N = this.scryptParams.N
-  var r = this.scryptParams.r
-  var p = this.scryptParams.p
+  var N = SCRYPT_PARAMS.N
+  var r = SCRYPT_PARAMS.r
+  var p = SCRYPT_PARAMS.p
 
   var scryptBuf = scrypt(secret, salt, N, r, p, 64, progressCallback)
   var derivedHalf1 = scryptBuf.slice(0, 32)
   var derivedHalf2 = scryptBuf.slice(32, 64)
 
   var xorBuf = xor(buffer, derivedHalf1)
-  var cipher = aes.createCipheriv('aes-256-ecb', derivedHalf2, new Buffer(0))
+  var cipher = aes.createCipheriv('aes-256-ecb', derivedHalf2, NULL)
   cipher.setAutoPadding(false)
   cipher.end(xorBuf)
 
   var cipherText = cipher.read()
 
-  // 0x01 + 0x42 + flagByte + salt + cipherText
-  var flagByte = compressed ? 0xe0 : 0xc0
-  var prefix = new Buffer(3)
-  prefix.writeUInt8(0x01, 0)
-  prefix.writeUInt8(0x42, 1)
-  prefix.writeUInt8(flagByte, 2)
+  // 0x01 | 0x42 | flagByte | salt (4) | cipherText (32)
+  var result = new Buffer(7 + 32)
+  result.writeUInt8(0x01, 0)
+  result.writeUInt8(0x42, 1)
+  result.writeUInt8(compressed ? 0xe0 : 0xc0, 2)
+  salt.copy(result, 3)
+  cipherText.copy(result, 7)
 
-  return Buffer.concat([prefix, salt, cipherText])
+  return result
 }
 
-Bip38.prototype.encrypt = function (wif, passphrase, saltAddress, progressCallback) {
-  var d = cs.decode(wif).slice(1)
-  var compressed = (d.length === 33) && (d[32] === 0x01)
-
-  // truncate the compression flag
-  if (compressed) {
-    d = d.slice(0, -1)
-  }
-
-  return cs.encode(this.encryptRaw(d, compressed, passphrase, saltAddress, progressCallback))
+function encrypt (buffer, compressed, passphrase, address, progressCallback) {
+  return bs58check.encode(encryptRaw(buffer, compressed, passphrase, address, progressCallback))
 }
 
 // some of the techniques borrowed from: https://github.com/pointbiz/bitaddress.org
 // todo: (optimization) init buffer in advance, and use copy instead of concat
-Bip38.prototype.decryptRaw = function (encData, passphrase, progressCallback) {
+function decryptRaw (buffer, passphrase, progressCallback) {
   // 39 bytes: 2 bytes prefix, 37 bytes payload
-  assert.equal(encData.length, 39, 'Invalid BIP38 data length')
-
-  // first byte is always 0x01
-  assert.equal(encData.readUInt8(0), 0x01, 'Invalid BIP38 prefix')
+  if (buffer.length !== 39) throw new Error('Invalid BIP38 data length')
+  if (buffer.readUInt8(0) !== 0x01) throw new Error('Invalid BIP38 prefix')
 
   // check if BIP38 EC multiply
-  var type = encData.readUInt8(1)
-  if (type === 0x43) {
-    return this.decryptECMult(encData, passphrase, progressCallback)
-  }
+  var type = buffer.readUInt8(1)
+  if (type === 0x43) return decryptECMult(buffer, passphrase, progressCallback)
+  if (type !== 0x42) throw new Error('Invalid BIP38 type')
 
   passphrase = new Buffer(passphrase, 'utf8')
 
-  assert.equal(type, 0x42, 'Invalid BIP38 type')
-  var flagByte = encData.readUInt8(2)
+  var flagByte = buffer.readUInt8(2)
   var compressed = flagByte === 0xe0
+  if (!compressed && flagByte !== 0xc0) throw new Error('Invalid BIP38 compression flag')
 
-  if (!compressed) {
-    assert.equal(flagByte, 0xc0, 'Invalid BIP38 compression flag')
-  }
+  var N = SCRYPT_PARAMS.N
+  var r = SCRYPT_PARAMS.r
+  var p = SCRYPT_PARAMS.p
 
-  var N = this.scryptParams.N
-  var r = this.scryptParams.r
-  var p = this.scryptParams.p
-
-  var addresshash = encData.slice(3, 7)
-  var scryptBuf = scrypt(passphrase, addresshash, N, r, p, 64, progressCallback)
+  var salt = buffer.slice(3, 7)
+  var scryptBuf = scrypt(passphrase, salt, N, r, p, 64, progressCallback)
   var derivedHalf1 = scryptBuf.slice(0, 32)
   var derivedHalf2 = scryptBuf.slice(32, 64)
 
-  var privKeyBuf = encData.slice(7, 7 + 32)
-  var decipher = aes.createDecipheriv('aes-256-ecb', derivedHalf2, new Buffer(0))
+  var privKeyBuf = buffer.slice(7, 7 + 32)
+  var decipher = aes.createDecipheriv('aes-256-ecb', derivedHalf2, NULL)
   decipher.setAutoPadding(false)
   decipher.end(privKeyBuf)
 
   var plainText = decipher.read()
   var privateKey = xor(plainText, derivedHalf1)
+
+  // verify salt matches address
+//   var d = BigInteger.fromBuffer(privateKey)
+//   var address = getAddress(d)
+//   var checksum = hash256(address).slice(0, 4)
+//   assert.deepEqual(salt, checksum)
 
   return {
     privateKey: privateKey,
@@ -121,35 +125,22 @@ Bip38.prototype.decryptRaw = function (encData, passphrase, progressCallback) {
   }
 }
 
-Bip38.prototype.decrypt = function (encryptedBase58, passphrase, progressCallback) {
-  var encBuffer = cs.decode(encryptedBase58)
-  var decrypt = this.decryptRaw(encBuffer, passphrase, progressCallback)
-
-  // Convert to WIF
-  var bufferLen = decrypt.compressed ? 34 : 33
-  var buffer = new Buffer(bufferLen)
-
-  buffer.writeUInt8(this.versions.private, 0)
-  decrypt.privateKey.copy(buffer, 1)
-
-  if (decrypt.compressed) {
-    buffer.writeUInt8(0x01, 33)
-  }
-
-  return cs.encode(buffer)
+function decrypt (string, passphrase, progressCallback) {
+  return decryptRaw(bs58check.decode(string), passphrase, progressCallback)
 }
 
-Bip38.prototype.decryptECMult = function (encData, passphrase, progressCallback) {
+function decryptECMult (buffer, passphrase, progressCallback) {
   passphrase = new Buffer(passphrase, 'utf8')
-  encData = encData.slice(1) // FIXME: we can avoid this
+  buffer = buffer.slice(1) // FIXME: we can avoid this
 
-  var compressed = (encData[1] & 0x20) !== 0
-  var hasLotSeq = (encData[1] & 0x04) !== 0
+  var flag = buffer.readUInt8(1)
+  var compressed = (flag & 0x20) !== 0
+  var hasLotSeq = (flag & 0x04) !== 0
 
-  assert.equal((encData[1] & 0x24), encData[1], 'Invalid private key.')
+  assert.equal((flag & 0x24), flag, 'Invalid private key.')
 
-  var addresshash = encData.slice(2, 6)
-  var ownerEntropy = encData.slice(6, 14)
+  var addressHash = buffer.slice(2, 6)
+  var ownerEntropy = buffer.slice(6, 14)
   var ownerSalt
 
   // 4 bytes ownerSalt if 4 bytes lot/sequence
@@ -161,18 +152,18 @@ Bip38.prototype.decryptECMult = function (encData, passphrase, progressCallback)
     ownerSalt = ownerEntropy
   }
 
-  var encryptedPart1 = encData.slice(14, 22) // First 8 bytes
-  var encryptedPart2 = encData.slice(22, 38) // 16 bytes
+  var encryptedPart1 = buffer.slice(14, 22) // First 8 bytes
+  var encryptedPart2 = buffer.slice(22, 38) // 16 bytes
 
-  var N = this.scryptParams.N
-  var r = this.scryptParams.r
-  var p = this.scryptParams.p
+  var N = SCRYPT_PARAMS.N
+  var r = SCRYPT_PARAMS.r
+  var p = SCRYPT_PARAMS.p
   var preFactor = scrypt(passphrase, ownerSalt, N, r, p, 32, progressCallback)
 
   var passFactor
   if (hasLotSeq) {
     var hashTarget = Buffer.concat([preFactor, ownerEntropy])
-    passFactor = sha256x2(hashTarget)
+    passFactor = hash256(hashTarget)
   } else {
     passFactor = preFactor
   }
@@ -180,7 +171,7 @@ Bip38.prototype.decryptECMult = function (encData, passphrase, progressCallback)
   var passInt = BigInteger.fromBuffer(passFactor)
   var passPoint = curve.G.multiply(passInt).getEncoded(true)
 
-  var seedBPass = scrypt(passPoint, Buffer.concat([addresshash, ownerEntropy]), 1024, 1, 1, 64)
+  var seedBPass = scrypt(passPoint, Buffer.concat([addressHash, ownerEntropy]), 1024, 1, 1, 64)
   var derivedHalf1 = seedBPass.slice(0, 32)
   var derivedHalf2 = seedBPass.slice(32, 64)
 
@@ -199,10 +190,10 @@ Bip38.prototype.decryptECMult = function (encData, passphrase, progressCallback)
 
   var seedBPart1 = xor(decipher2.read(), derivedHalf1.slice(0, 16))
   var seedB = Buffer.concat([seedBPart1, seedBPart2], 24)
-  var factorB = sha256x2(seedB)
+  var factorB = BigInteger.fromBuffer(hash256(seedB))
 
   // d = passFactor * factorB (mod n)
-  var d = passInt.multiply(BigInteger.fromBuffer(factorB)).mod(curve.n)
+  var d = passInt.multiply(factorB).mod(curve.n)
 
   return {
     privateKey: d.toBuffer(32),
@@ -210,13 +201,9 @@ Bip38.prototype.decryptECMult = function (encData, passphrase, progressCallback)
   }
 }
 
-Bip38.prototype.verify = function (encryptedBase58) {
-  var decoded
-  try {
-    decoded = cs.decode(encryptedBase58)
-  } catch (e) {
-    return false
-  }
+function verify (string) {
+  var decoded = bs58check.decodeUnsafe(string)
+  if (!decoded) return false
 
   if (decoded.length !== 39) return false
   if (decoded.readUInt8(0) !== 0x01) return false
@@ -238,4 +225,11 @@ Bip38.prototype.verify = function (encryptedBase58) {
   return true
 }
 
-module.exports = Bip38
+module.exports = {
+  decrypt: decrypt,
+  decryptECMult: decryptECMult,
+  decryptRaw: decryptRaw,
+  encrypt: encrypt,
+  encryptRaw: encryptRaw,
+  verify: verify
+}

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function encryptRaw (buffer, compressed, passphrase, progressCallback) {
   if (buffer.length !== 32) throw new Error('Invalid private key length')
 
   var d = BigInteger.fromBuffer(buffer)
-  var address = getAddress(d)
+  var address = getAddress(d, compressed)
   var secret = new Buffer(passphrase, 'utf8')
   var salt = hash256(address).slice(0, 4)
 
@@ -114,10 +114,10 @@ function decryptRaw (buffer, passphrase, progressCallback) {
   var privateKey = xor(plainText, derivedHalf1)
 
   // verify salt matches address
-//   var d = BigInteger.fromBuffer(privateKey)
-//   var address = getAddress(d)
-//   var checksum = hash256(address).slice(0, 4)
-//   assert.deepEqual(salt, checksum)
+  var d = BigInteger.fromBuffer(privateKey)
+  var address = getAddress(d, compressed)
+  var checksum = hash256(address).slice(0, 4)
+  assert.deepEqual(salt, checksum)
 
   return {
     privateKey: privateKey,

--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ function encrypt (buffer, compressed, passphrase, address, progressCallback, scr
 }
 
 // some of the techniques borrowed from: https://github.com/pointbiz/bitaddress.org
-// todo: (optimization) init buffer in advance, and use copy instead of concat
 function decryptRaw (buffer, passphrase, progressCallback, scryptParams) {
   // 39 bytes: 2 bytes prefix, 37 bytes payload
   if (buffer.length !== 39) throw new Error('Invalid BIP38 data length')

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "bigi": "^1.2.0",
     "browserify-aes": "^1.0.1",
+    "bs58check": "^1.3.1",
     "buffer-xor": "^1.0.2",
-    "coinstring": "^2.2.0",
     "create-hash": "^1.1.1",
     "ecurve": "^1.0.0",
     "scryptsy": "^1.2.0"
@@ -25,7 +25,8 @@
     "istanbul": "^0.2.11",
     "mocha": "^2.3.3",
     "mochify": "^2.1.1",
-    "standard": "^5.0.2"
+    "standard": "^5.0.2",
+    "wif": "^2.0.1"
   },
   "repository": {
     "url": "git@github.com:bitcoinjs/bip38.git",

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ var fixtures = require('./fixtures')
 var wif = require('wif')
 
 describe('bip38', function () {
-  this.timeout(70000)
+  this.timeout(200000)
 
   describe('decrypt', function () {
     fixtures.valid.forEach(function (f) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,19 +1,20 @@
-var assert = require('assert')
-var Bip38 = require('../')
-var fixtures = require('./fixtures')
+/* global describe, it */
 
-/* global beforeEach, describe, it */
+var assert = require('assert')
+var bip38 = require('../')
+var bs58check = require('bs58check')
+var fixtures = require('./fixtures')
+var wif = require('wif')
 
 describe('bip38', function () {
-  var bip38
-  beforeEach(function () {
-    bip38 = new Bip38()
-  })
+  this.timeout(70000)
 
   describe('decrypt', function () {
     fixtures.valid.forEach(function (f) {
       it('should decrypt ' + f.description, function () {
-        assert.equal(bip38.decrypt(f.bip38, f.passphrase), f.wif)
+        var result = bip38.decrypt(f.bip38, f.passphrase)
+
+        assert.equal(wif.encode(0x80, result.privateKey, result.compressed), f.wif)
       })
     })
 
@@ -39,7 +40,9 @@ describe('bip38', function () {
       if (f.decryptOnly) return
 
       it('should encrypt ' + f.description, function () {
-        assert.equal(bip38.encrypt(f.wif, f.passphrase, f.address), f.bip38)
+        var buffer = bs58check.decode(f.wif)
+
+        assert.equal(bip38.encrypt(buffer.slice(1, 33), !!buffer[33], f.passphrase), f.bip38)
       })
     })
   })


### PR DESCRIPTION
Resolves all remaining points in https://github.com/bitcoinjs/bip38/issues/5.
Specifically:
- consider removing coinstring [DONE]
- consider removing class instantiation, ~~pass script params as optional param~~ [DONE]

Script params were not put as optional, as there has been at least some consensus over time that the parameters given are suitable.
Happy to revise that.

I did not only keep the raw methods, as I felt the base58check encoded BIP38 string was important and specific to the encoding of this module.

Instead, I remove encoding/decoding of WIF format private keys as part of the `encrypt` interface.  You now specifically pass in a private key 32-byte buffer with a compression flag.
