### PR TITLE
Add network params support

### DIFF
--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -19,6 +19,28 @@
       "bip38": "6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo",
       "wif": "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP",
       "address": "164MQi977u9GUteHr4EPH27VkkdxmfCvGW",
+      "description": "with specified (BITCOIN) network / no EC multiply / compression #1",
+      "network": {
+        "private": 128,
+        "public": 0
+      }
+    },
+    {
+      "passphrase": "password",
+      "bip38": "6PYUdkYbzk9G1Khmf3pRZhcLzqtZJqt9ZnkFjVkYvi76FesXSfH2Q5jTrX",
+      "wif": "c4TkW4HHWNumqzhD8tqktx5Rgxmj7a848Us5fpkoBGEjkuqvxfjQ",
+      "address": "CJ7Msqva4HLvx2GyupMUz5usUB8UpBVEoW",
+      "description": "with custom (CITY) network / no EC multiply / compression #1",
+      "network": {
+        "private": 237,
+        "public": 28
+      }
+    },
+    {
+      "passphrase": "TestingOneTwoThree",
+      "bip38": "6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo",
+      "wif": "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP",
+      "address": "164MQi977u9GUteHr4EPH27VkkdxmfCvGW",
       "description": "no EC multiply / compression #1"
     },
     {

--- a/test/index.js
+++ b/test/index.js
@@ -12,9 +12,9 @@ describe('bip38', function () {
   describe('decrypt', function () {
     fixtures.valid.forEach(function (f) {
       it('should decrypt ' + f.description, function () {
-        var result = bip38.decrypt(f.bip38, f.passphrase)
-
-        assert.equal(wif.encode(0x80, result.privateKey, result.compressed), f.wif)
+        var result = bip38.decrypt(f.bip38, f.passphrase, null, null, f.network)
+        var prefix = f.network ? f.network.private : 0x80
+        assert.equal(wif.encode(prefix, result.privateKey, result.compressed), f.wif)
       })
     })
 
@@ -42,7 +42,7 @@ describe('bip38', function () {
       it('should encrypt ' + f.description, function () {
         var buffer = bs58check.decode(f.wif)
 
-        assert.equal(bip38.encrypt(buffer.slice(1, 33), !!buffer[33], f.passphrase), f.bip38)
+        assert.equal(bip38.encrypt(buffer.slice(1, 33), !!buffer[33], f.passphrase, null, null, f.network), f.bip38)
       })
     })
   })


### PR DESCRIPTION
- Previous version (1.4.0) supported specify an instance based verson configuration that held network prefixes. This was missing from the latest, and this commit adds support for networks using an additional parameter to encrypt/decrypt.
- Add a test case for CITY (City Chain) network to verify custom network support.

Closes #20

Test result:
![image](https://user-images.githubusercontent.com/309938/52677791-9c137500-2f2f-11e9-8e10-dafad0889493.png)
