### PR TITLE
add safe-buffer as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1317,6 +1317,14 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         },
         "isarray": {
@@ -5090,6 +5098,14 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         },
         "find-up": {
@@ -5796,6 +5812,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "readdirp": {
@@ -6538,6 +6562,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "buffer-xor": "^1.0.2",
     "create-hash": "^1.1.1",
     "ecurve": "^1.0.0",
+    "safe-buffer": "~5.1.1",
     "scryptsy": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This package can't be used with Plug'n'Play which is a feature of Yarn Berry because it relies on implicit dependencies.

```
bip38 tried to access safe-buffer, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: safe-buffer (via "safe-buffer")
Required by: bip38@npm:3.1.0 (via /Users/brian/Code/platform-sdk/.yarn/cache/bip38-npm-3.1.0-f2bcae6b96-2.zip/node_modules/bip38/)
```

Adding `safe-buffer` as a direct dependency resolves this issue.